### PR TITLE
[[im/subscribe]]Add IM subscription support upon IM read

### DIFF
--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -92,15 +92,11 @@ struct ClusterInfo
     }
 
     ClusterInfo() {}
-    bool IsDirty() { return mDirty; }
-    void SetDirty() { mDirty = true; }
-    void ClearDirty() { mDirty = false; }
     NodeId mNodeId         = 0;
     ClusterId mClusterId   = 0;
     ListIndex mListIndex   = 0;
     AttributeId mFieldId   = 0;
     EndpointId mEndpointId = 0;
-    bool mDirty            = false;
     BitFlags<Flags> mFlags;
     ClusterInfo * mpNext = nullptr;
     EventId mEventId     = 0;

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -40,6 +40,7 @@ static constexpr uint32_t kImMessageTimeoutMsec = 12000;
 class ReadClient;
 class WriteClient;
 class CommandSender;
+class ReadHandler;
 
 /**
  * @brief
@@ -196,7 +197,17 @@ public:
     }
 
     /**
-     * Notification that a read client has completed the current interaction.
+     * Notification that a Subscribe Response has been processed and application can do further work .
+     */
+    virtual CHIP_ERROR SubscribeResponseProcessed(const ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * Notification that Subscription has been established successfully and application can do further work in handler.
+     */
+    virtual CHIP_ERROR SubscriptionEstablished(const ReadHandler * apReadHandler) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * Notification that a read interaction was completed on the client successfully.
      * @param[in]  apReadClient  A current read client which can identify the read client to the consumer, particularly
      * during multiple read interactions
      * @param[in]  aError  notify final error regarding the current read interaction

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -106,10 +106,11 @@ void InteractionModelEngine::Shutdown()
         VerifyOrDie(writeHandler.IsFree());
     }
 
+    mReportingEngine.Shutdown();
+
     for (uint32_t index = 0; index < CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS; index++)
     {
         mClusterInfoPool[index].mpNext = nullptr;
-        mClusterInfoPool[index].ClearDirty();
     }
 
     mpNextAvailableClusterInfo = nullptr;
@@ -137,7 +138,8 @@ CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apCom
     return CHIP_ERROR_NO_MEMORY;
 }
 
-CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClient, uint64_t aAppIdentifier)
+CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClient, ReadClient::InteractionType aInteractionType,
+                                                 uint64_t aAppIdentifier)
 {
     CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
 
@@ -146,7 +148,7 @@ CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClien
         if (readClient.IsFree())
         {
             *apReadClient = &readClient;
-            err           = readClient.Init(mpExchangeMgr, mpDelegate, aAppIdentifier);
+            err           = readClient.Init(mpExchangeMgr, mpDelegate, aInteractionType, aAppIdentifier);
             if (CHIP_NO_ERROR != err)
             {
                 *apReadClient = nullptr;
@@ -231,17 +233,19 @@ exit:
 
 CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext,
                                                         const PacketHeader & aPacketHeader, const PayloadHeader & aPayloadHeader,
-                                                        System::PacketBufferHandle && aPayload)
+                                                        System::PacketBufferHandle && aPayload,
+                                                        ReadHandler::InteractionType aInteractionType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogDetail(InteractionModel, "Receive Read request");
+    ChipLogDetail(InteractionModel, "Receive %s request",
+                  aInteractionType == ReadHandler::InteractionType::Subscribe ? "Subscribe" : "Read");
 
     for (auto & readHandler : mReadHandlers)
     {
         if (readHandler.IsFree())
         {
-            err = readHandler.Init(mpExchangeMgr, mpDelegate, apExchangeContext);
+            err = readHandler.Init(mpExchangeMgr, mpDelegate, apExchangeContext, aInteractionType);
             SuccessOrExit(err);
             err               = readHandler.OnReadInitialRequest(std::move(aPayload));
             apExchangeContext = nullptr;
@@ -289,6 +293,42 @@ exit:
     return err;
 }
 
+CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext,
+                                                           const PacketHeader & aPacketHeader, const PayloadHeader & aPayloadHeader,
+                                                           System::PacketBufferHandle && aPayload)
+{
+    System::PacketBufferTLVReader reader;
+    reader.Init(aPayload.Retain());
+    ReturnLogErrorOnFailure(reader.Next());
+
+    ReportData::Parser report;
+    ReturnLogErrorOnFailure(report.Init(reader));
+
+    uint64_t subscriptionId = 0;
+    ReturnLogErrorOnFailure(report.GetSubscriptionId(&subscriptionId));
+
+    for (auto & readClient : mReadClients)
+    {
+        if (!readClient.IsSubscriptionTypeIdle())
+        {
+            continue;
+        }
+        if (!readClient.IsMatchingClient(subscriptionId))
+        {
+            continue;
+        }
+
+        readClient.SetExchangeContext(apExchangeContext);
+        CHIP_ERROR err = readClient.ProcessReportData(std::move(aPayload));
+        if (err != CHIP_NO_ERROR)
+        {
+            readClient.Shutdown();
+        }
+        return err;
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext,
                                                      const PacketHeader & aPacketHeader, const PayloadHeader & aPayloadHeader,
                                                      System::PacketBufferHandle && aPayload)
@@ -299,11 +339,21 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReadRequest))
     {
-        return OnReadInitialRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+        return OnReadInitialRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload),
+                                    ReadHandler::InteractionType::Read);
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::WriteRequest))
     {
         return OnWriteRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+    }
+    else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::SubscribeRequest))
+    {
+        return OnReadInitialRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload),
+                                    ReadHandler::InteractionType::Subscribe);
+    }
+    else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReportData))
+    {
+        return OnUnsolicitedReportData(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
     }
     else
     {
@@ -320,8 +370,21 @@ CHIP_ERROR InteractionModelEngine::SendReadRequest(ReadPrepareParams & aReadPrep
 {
     ReadClient * client = nullptr;
     CHIP_ERROR err      = CHIP_NO_ERROR;
-    ReturnErrorOnFailure(NewReadClient(&client, aAppIdentifier));
+    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Read, aAppIdentifier));
     err = client->SendReadRequest(aReadPrepareParams);
+    if (err != CHIP_NO_ERROR)
+    {
+        client->Shutdown();
+    }
+    return err;
+}
+
+CHIP_ERROR InteractionModelEngine::SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier)
+{
+    ReadClient * client = nullptr;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Subscribe, aAppIdentifier));
+    err = client->SendSubscribeRequest(aReadPrepareParams);
     if (err != CHIP_NO_ERROR)
     {
         client->Shutdown();
@@ -349,10 +412,8 @@ void InteractionModelEngine::ReleaseClusterInfoList(ClusterInfo *& aClusterInfo)
 
     while (lastClusterInfo != nullptr && lastClusterInfo->mpNext != nullptr)
     {
-        lastClusterInfo->ClearDirty();
         lastClusterInfo = lastClusterInfo->mpNext;
     }
-    lastClusterInfo->ClearDirty();
     lastClusterInfo->mFlags.ClearAll();
     lastClusterInfo->mpNext    = mpNextAvailableClusterInfo;
     mpNextAvailableClusterInfo = aClusterInfo;
@@ -364,6 +425,7 @@ CHIP_ERROR InteractionModelEngine::PushFront(ClusterInfo *& aClusterInfoList, Cl
     ClusterInfo * last = aClusterInfoList;
     if (mpNextAvailableClusterInfo == nullptr)
     {
+        ChipLogProgress(InteractionModel, "There is no available cluster info in mClusterInfoPool");
         return CHIP_ERROR_NO_MEMORY;
     }
     aClusterInfoList           = mpNextAvailableClusterInfo;
@@ -371,6 +433,51 @@ CHIP_ERROR InteractionModelEngine::PushFront(ClusterInfo *& aClusterInfoList, Cl
     *aClusterInfoList          = aClusterInfo;
     aClusterInfoList->mpNext   = last;
     return CHIP_NO_ERROR;
+}
+
+bool InteractionModelEngine::MergeOverlappedAttributePath(ClusterInfo * apAttributePathList, ClusterInfo & aAttributePath)
+{
+    ClusterInfo * runner = apAttributePathList;
+    while (runner != nullptr)
+    {
+        // If overlapped, we would skip this target path,
+        // --If targetPath is part of previous path, return true
+        // --If previous path is part of target path, update filedid and listindex and mflags with target path, return true
+        if (runner->IsAttributePathSupersetOf(aAttributePath))
+        {
+            return true;
+        }
+        if (aAttributePath.IsAttributePathSupersetOf(*runner))
+        {
+            runner->mListIndex = aAttributePath.mListIndex;
+            runner->mFieldId   = aAttributePath.mFieldId;
+            runner->mFlags     = aAttributePath.mFlags;
+            return true;
+        }
+        runner = runner->mpNext;
+    }
+    return false;
+}
+
+bool InteractionModelEngine::IsOverlappedAttributePath(ClusterInfo & aAttributePath)
+{
+    for (auto & handler : mReadHandlers)
+    {
+        if (handler.IsSubscriptionType() && (handler.IsGeneratingReports() || handler.IsAwaitingReportResponse()))
+        {
+            for (auto clusterInfo = handler.GetAttributeClusterInfolist(); clusterInfo != nullptr;
+                 clusterInfo      = clusterInfo->mpNext)
+            {
+                if (clusterInfo->IsAttributePathSupersetOf(aAttributePath) ||
+                    aAttributePath.IsAttributePathSupersetOf(*clusterInfo))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    ChipLogDetail(DataManagement, "AttributePath is not interested");
+    return false;
 }
 
 } // namespace app

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -112,6 +112,14 @@ public:
     CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
 
     /**
+     *  Creates a new read client and sends SubscribeRequest message to the node using the read client.
+     *  Shuts down on transmission failure.
+     *
+     *  @retval #CHIP_ERROR_NO_MEMORY If there is no ReadClient available
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
+    /**
      *  Retrieve a WriteClient that the SDK consumer can use to send a write.  If the call succeeds,
      *  see WriteClient documentation for lifetime handling.
      *
@@ -141,6 +149,10 @@ public:
 
     void ReleaseClusterInfoList(ClusterInfo *& aClusterInfo);
     CHIP_ERROR PushFront(ClusterInfo *& aClusterInfoLisst, ClusterInfo & aClusterInfo);
+    // Merges aAttributePath inside apAttributePathList if current path is overlapped with existing path in apAttributePathList
+    // Overlap means the path is superset or subset of another path
+    bool MergeOverlappedAttributePath(ClusterInfo * apAttributePathList, ClusterInfo & aAttributePath);
+    bool IsOverlappedAttributePath(ClusterInfo & aAttributePath);
 
 private:
     friend class reporting::Engine;
@@ -157,7 +169,8 @@ private:
      * the Read Request are handled entirely within this function.
      */
     CHIP_ERROR OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
-                                    const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
+                                    const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload,
+                                    ReadHandler::InteractionType aInteractionType);
 
     /**
      * Called when Interaction Model receives a Write Request message.  Errors processing
@@ -166,6 +179,11 @@ private:
     CHIP_ERROR OnWriteRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                               const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
 
+    /**This function handles processing of un-solicited ReportData messages on the client, which can
+     * only occur post subscription establishment
+     */
+    CHIP_ERROR OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                                       const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
     /**
      *  Retrieve a ReadClient that the SDK consumer can use to send do a read.  If the call succeeds, the consumer
      *  is responsible for calling Shutdown() on the ReadClient once it's done using it.
@@ -173,7 +191,8 @@ private:
      *  @retval #CHIP_ERROR_INCORRECT_STATE If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, uint64_t aAppIdentifier);
+    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, ReadClient::InteractionType aInteractionType,
+                             uint64_t aAppIdentifier);
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -24,6 +24,8 @@
 
 #include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
+#include <app/MessageDef/SubscribeRequest.h>
+#include <app/MessageDef/SubscribeResponse.h>
 #include <app/ReadClient.h>
 #include <protocols/secure_channel/StatusReport.h>
 
@@ -31,18 +33,22 @@ namespace chip {
 namespace app {
 
 CHIP_ERROR ReadClient::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
-                            uint64_t aAppIdentifier)
+                            InteractionType aInteractionType, uint64_t aAppIdentifier)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Error if already initialized.
+    VerifyOrExit(IsFree(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(apExchangeMgr != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mpExchangeMgr == nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    mpExchangeMgr  = apExchangeMgr;
-    mpDelegate     = apDelegate;
-    mState         = ClientState::Initialized;
-    mAppIdentifier = aAppIdentifier;
-    mInitialReport = true;
+    mpExchangeMgr           = apExchangeMgr;
+    mpDelegate              = apDelegate;
+    mState                  = ClientState::Initialized;
+    mAppIdentifier          = aAppIdentifier;
+    mMinSyncIntervalSeconds = 0;
+    mMaxSyncIntervalSeconds = 0;
+    mSubscriptionId         = 0;
+    mInitialReport          = true;
+    mInteractionType        = aInteractionType;
     AbortExistingExchangeContext();
 
 exit:
@@ -64,12 +70,23 @@ void ReadClient::ShutdownInternal(CHIP_ERROR aError)
         {
             mpDelegate->ReadError(this, aError);
         }
-        mpDelegate->ReadDone(this);
+        else
+        {
+            mpDelegate->ReadDone(this);
+        }
         mpDelegate = nullptr;
     }
-    mpExchangeMgr  = nullptr;
-    mpExchangeCtx  = nullptr;
-    mInitialReport = true;
+    if (IsSubscriptionType())
+    {
+        CancelLivenessCheckTimer();
+    }
+    mMinSyncIntervalSeconds = 0;
+    mMaxSyncIntervalSeconds = 0;
+    mSubscriptionId         = 0;
+    mInteractionType        = InteractionType::Read;
+    mpExchangeMgr           = nullptr;
+    mpExchangeCtx           = nullptr;
+    mInitialReport          = true;
     MoveToState(ClientState::Uninitialized);
 }
 
@@ -84,6 +101,10 @@ const char * ReadClient::GetStateStr() const
         return "INIT";
     case ClientState::AwaitingInitialReport:
         return "AwaitingInitialReport";
+    case ClientState::AwaitingSubscribeResponse:
+        return "AwaitingSubscribeResponse";
+    case ClientState::SubscriptionIdle:
+        return "SubscriptionIdle";
     }
 #endif // CHIP_DETAIL_LOGGING
     return "N/A";
@@ -177,7 +198,6 @@ CHIP_ERROR ReadClient::SendStatusReport(CHIP_ERROR aError)
     Protocols::SecureChannel::GeneralStatusCode generalCode = Protocols::SecureChannel::GeneralStatusCode::kSuccess;
     uint32_t protocolId                                     = Protocols::InteractionModel::Id.ToFullyQualifiedSpecForm();
     uint16_t protocolCode                                   = to_underlying(Protocols::InteractionModel::ProtocolCode::Success);
-    bool expectResponse                                     = false;
     VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     if (aError != CHIP_NO_ERROR)
@@ -193,9 +213,21 @@ CHIP_ERROR ReadClient::SendStatusReport(CHIP_ERROR aError)
     System::PacketBufferHandle msgBuf = buf.Finalize();
     VerifyOrReturnLogError(!msgBuf.IsNull(), CHIP_ERROR_NO_MEMORY);
 
-    ReturnLogErrorOnFailure(mpExchangeCtx->SendMessage(
-        Protocols::SecureChannel::MsgType::StatusReport, std::move(msgBuf),
-        Messaging::SendFlags(expectResponse ? Messaging::SendMessageFlags::kExpectResponse : Messaging::SendMessageFlags::kNone)));
+    if (IsSubscriptionType())
+    {
+        if (IsAwaitingInitialReport())
+        {
+            MoveToState(ClientState::AwaitingSubscribeResponse);
+        }
+        else
+        {
+            RefreshLivenessCheckTimer();
+        }
+    }
+    ReturnLogErrorOnFailure(
+        mpExchangeCtx->SendMessage(Protocols::SecureChannel::MsgType::StatusReport, std::move(msgBuf),
+                                   Messaging::SendFlags(IsAwaitingSubscribeResponse() ? Messaging::SendMessageFlags::kExpectResponse
+                                                                                      : Messaging::SendMessageFlags::kNone)));
     return CHIP_NO_ERROR;
 }
 
@@ -264,6 +296,12 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
         err = ProcessReportData(std::move(aPayload));
         SuccessOrExit(err);
     }
+    else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::SubscribeResponse))
+    {
+        VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+        err = ProcessSubscribeResponse(std::move(aPayload));
+        SuccessOrExit(err);
+    }
     else
     {
         err = CHIP_ERROR_INVALID_MESSAGE_TYPE;
@@ -271,8 +309,10 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
 
 exit:
     ChipLogFunctError(err);
-    ShutdownInternal(err);
-
+    if (!IsSubscriptionType() || err != CHIP_NO_ERROR)
+    {
+        ShutdownInternal(err);
+    }
     return err;
 }
 
@@ -296,6 +336,7 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     bool isAttributeDataListPresent = false;
     bool suppressResponse           = false;
     bool moreChunkedMessages        = false;
+    uint64_t subscriptionId         = 0;
     EventList::Parser eventList;
     AttributeDataList::Parser attributeDataList;
     System::PacketBufferTLVReader reader;
@@ -318,10 +359,31 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     }
     SuccessOrExit(err);
 
-    if (IsInitialReport())
+    err = report.GetSubscriptionId(&subscriptionId);
+    if (CHIP_NO_ERROR == err)
     {
-        ChipLogProgress(DataManagement, "ProcessReportData handles the initial report");
+        if (IsInitialReport())
+        {
+            mSubscriptionId = subscriptionId;
+        }
+        else if (!IsMatchingClient(subscriptionId))
+        {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+        }
     }
+    else if (CHIP_END_OF_TLV == err)
+    {
+        if (IsSubscriptionType())
+        {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        else
+        {
+            err = CHIP_NO_ERROR;
+        }
+    }
+    SuccessOrExit(err);
+
     err = report.GetMoreChunkedMessages(&moreChunkedMessages);
     if (CHIP_END_OF_TLV == err)
     {
@@ -373,6 +435,10 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
 exit:
     ChipLogFunctError(err);
     SendStatusReport(err);
+    if (!mInitialReport)
+    {
+        mpExchangeCtx = nullptr;
+    }
     mInitialReport = false;
     return err;
 }
@@ -459,5 +525,140 @@ exit:
     ChipLogFunctError(err);
     return err;
 }
+
+CHIP_ERROR ReadClient::RefreshLivenessCheckTimer()
+{
+    CancelLivenessCheckTimer();
+    ChipLogProgress(DataManagement, "Refresh LivenessCheckTime with %d seconds", mMaxSyncIntervalSeconds);
+    CHIP_ERROR err = InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->StartTimer(
+        mMaxSyncIntervalSeconds * kMillisecondsPerSecond, OnLivenessTimeoutCallback, this);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogFunctError(err);
+        ShutdownInternal(err);
+    }
+    return err;
+}
+
+void ReadClient::CancelLivenessCheckTimer()
+{
+    InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->CancelTimer(
+        OnLivenessTimeoutCallback, this);
+}
+
+void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState)
+{
+    ReadClient * const client = reinterpret_cast<ReadClient *>(apAppState);
+    ChipLogError(DataManagement, "Subscription Liveness timeout, shutting down");
+    if (client->IsFree())
+    {
+        ChipLogError(DataManagement,
+                     "ReadClient::OnLivenessTimeoutCallback invoked on a free client! This is a bug in CHIP stack!");
+        return;
+    }
+    // TODO: add a more specific error here for liveness timeout failure to distinguish between other classes of timeouts (i.e
+    // response timeouts).
+    client->ShutdownInternal(CHIP_ERROR_TIMEOUT);
+}
+
+CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aPayload)
+{
+    System::PacketBufferTLVReader reader;
+    reader.Init(std::move(aPayload));
+    ReturnLogErrorOnFailure(reader.Next());
+
+    SubscribeResponse::Parser subscribeResponse;
+    ReturnLogErrorOnFailure(subscribeResponse.Init(reader));
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    ReturnLogErrorOnFailure(subscribeResponse.CheckSchemaValidity());
+#endif
+
+    uint64_t subscriptionId = 0;
+    ReturnLogErrorOnFailure(subscribeResponse.GetSubscriptionId(&subscriptionId));
+    VerifyOrReturnLogError(IsMatchingClient(subscriptionId), CHIP_ERROR_INVALID_ARGUMENT);
+
+    ReturnLogErrorOnFailure(subscribeResponse.GetFinalSyncIntervalSeconds(&mMaxSyncIntervalSeconds));
+    mpDelegate->SubscribeResponseProcessed(this);
+
+    if (IsAwaitingSubscribeResponse())
+    {
+        MoveToState(ClientState::SubscriptionIdle);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle msgBuf;
+    System::PacketBufferTLVWriter writer;
+    SubscribeRequest::Builder request;
+    VerifyOrExit(ClientState::Initialized == mState, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    msgBuf = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);
+    VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+    AbortExistingExchangeContext();
+
+    writer.Init(std::move(msgBuf));
+
+    err = request.Init(&writer);
+    SuccessOrExit(err);
+
+    if (aReadPrepareParams.mEventPathParamsListSize != 0 && aReadPrepareParams.mpEventPathParamsList != nullptr)
+    {
+        EventPathList::Builder & eventPathListBuilder = request.CreateEventPathListBuilder();
+        SuccessOrExit(err = eventPathListBuilder.GetError());
+        err = GenerateEventPathList(eventPathListBuilder, aReadPrepareParams.mpEventPathParamsList,
+                                    aReadPrepareParams.mEventPathParamsListSize);
+        SuccessOrExit(err);
+
+        if (aReadPrepareParams.mEventNumber != 0)
+        {
+            // EventNumber is optional
+            request.EventNumber(aReadPrepareParams.mEventNumber);
+        }
+    }
+
+    if (aReadPrepareParams.mAttributePathParamsListSize != 0 && aReadPrepareParams.mpAttributePathParamsList != nullptr)
+    {
+        AttributePathList::Builder & attributePathListBuilder = request.CreateAttributePathListBuilder();
+        SuccessOrExit(err = attributePathListBuilder.GetError());
+        err = GenerateAttributePathList(attributePathListBuilder, aReadPrepareParams.mpAttributePathParamsList,
+                                        aReadPrepareParams.mAttributePathParamsListSize);
+        SuccessOrExit(err);
+    }
+
+    request.MinIntervalSeconds(aReadPrepareParams.mMinIntervalSeconds)
+        .MaxIntervalSeconds(aReadPrepareParams.mMaxIntervalSeconds)
+        .EndOfSubscribeRequest();
+    SuccessOrExit(err = request.GetError());
+
+    err = writer.Finalize(&msgBuf);
+    SuccessOrExit(err);
+
+    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHandle, this);
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    SuccessOrExit(err);
+    MoveToState(ClientState::AwaitingInitialReport);
+
+exit:
+    ChipLogFunctError(err);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        AbortExistingExchangeContext();
+    }
+
+    return err;
+}
+
 }; // namespace app
 }; // namespace chip

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -52,6 +52,11 @@ namespace app {
 class ReadClient : public Messaging::ExchangeDelegate
 {
 public:
+    enum class InteractionType : uint8_t
+    {
+        Read,
+        Subscribe,
+    };
     /**
      *  Shut down the Client. This terminates this instance of the object and releases
      *  all held resources.  The object must not be used after Shutdown() is called.
@@ -74,8 +79,19 @@ public:
      */
     CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams);
 
+    /**
+     *  Send a subscribe Request.  There can be one Subscribe Request outstanding on a given ReadClient.
+     *  If SendSubscribeRequest returns success, no more subscribe Requests can be sent on this ReadClient
+     *  until the corresponding InteractionModelDelegate::ReadDone call happens with guarantee.
+     *
+     *  @retval #others fail to send subscribe request
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aSubscribePrepareParams);
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
+    bool IsReadType() { return mInteractionType == InteractionType::Read; }
+    bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
     CHIP_ERROR SendStatusReport(CHIP_ERROR aError);
 
 private:
@@ -84,11 +100,17 @@ private:
 
     enum class ClientState
     {
-        Uninitialized = 0,     ///< The client has not been initialized
-        Initialized,           ///< The client has been initialized and is ready for a SendReadRequest
-        AwaitingInitialReport, ///< The client is waiting for initial report
+        Uninitialized = 0,         ///< The client has not been initialized
+        Initialized,               ///< The client has been initialized and is ready for a SendReadRequest
+        AwaitingInitialReport,     ///< The client is waiting for initial report
+        AwaitingSubscribeResponse, ///< The client is waiting for subscribe response
+        SubscriptionIdle,          ///< The client is maintaining subscription
     };
 
+    bool IsMatchingClient(uint64_t aSubscriptionId)
+    {
+        return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
+    }
     /**
      *  Initialize the client object. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -102,7 +124,8 @@ private:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate, uint64_t aAppIdentifier);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                    InteractionType aInteractionType, uint64_t aAppIdentifier);
 
     virtual ~ReadClient() = default;
 
@@ -115,7 +138,10 @@ private:
      *
      */
     bool IsFree() const { return mState == ClientState::Uninitialized; }
+    bool IsSubscriptionTypeIdle() const { return mState == ClientState::SubscriptionIdle; }
     bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
+    bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
+
     CHIP_ERROR GenerateEventPathList(EventPathList::Builder & aEventPathListBuilder, EventPathParams * apEventPathParamsList,
                                      size_t aEventPathParamsListSize);
     CHIP_ERROR GenerateAttributePathList(AttributePathList::Builder & aAttributeathListBuilder,
@@ -124,7 +150,10 @@ private:
 
     void SetExchangeContext(Messaging::ExchangeContext * apExchangeContext) { mpExchangeCtx = apExchangeContext; }
     void ClearExchangeContext() { mpExchangeCtx = nullptr; }
-
+    static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
+    CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
+    CHIP_ERROR RefreshLivenessCheckTimer();
+    void CancelLivenessCheckTimer();
     void MoveToState(const ClientState aTargetState);
     CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload);
     CHIP_ERROR AbortExistingExchangeContext();
@@ -142,6 +171,10 @@ private:
     ClientState mState                         = ClientState::Uninitialized;
     uint64_t mAppIdentifier                    = 0;
     bool mInitialReport                        = true;
+    uint16_t mMinSyncIntervalSeconds           = 0;
+    uint16_t mMaxSyncIntervalSeconds           = 0;
+    uint64_t mSubscriptionId                   = 0;
+    InteractionType mInteractionType           = InteractionType::Read;
 };
 
 }; // namespace app

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -25,17 +25,21 @@
 #include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPath.h>
+#include <app/MessageDef/SubscribeRequest.h>
+#include <app/MessageDef/SubscribeResponse.h>
 #include <app/ReadHandler.h>
 #include <app/reporting/Engine.h>
+#include <lib/support/RandUtils.h>
 #include <protocols/secure_channel/StatusReport.h>
 
 namespace chip {
 namespace app {
 CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
-                             Messaging::ExchangeContext * apExchangeContext)
+                             Messaging::ExchangeContext * apExchangeContext, InteractionType aInteractionType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Error if already initialized.
+    VerifyOrReturnError(IsFree(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     mpExchangeMgr              = apExchangeMgr;
     mpExchangeCtx              = apExchangeContext;
@@ -45,7 +49,11 @@ CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
     mCurrentPriority           = PriorityLevel::Invalid;
     mInitialReport             = true;
     MoveToState(HandlerState::Initialized);
-    mpDelegate = apDelegate;
+    mpDelegate       = apDelegate;
+    mSubscriptionId  = 0;
+    mHoldReport      = false;
+    mDirty           = false;
+    mInteractionType = aInteractionType;
     if (apExchangeContext != nullptr)
     {
         apExchangeContext->SetDelegate(this);
@@ -56,6 +64,11 @@ CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
 
 void ReadHandler::Shutdown(ShutdownOptions aOptions)
 {
+    if (IsSubscriptionType())
+    {
+        InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->CancelTimer(
+            OnRefreshSubscribeTimerSyncCallback, this);
+    }
     if (aOptions == ShutdownOptions::AbortCurrentExchange)
     {
         if (mpExchangeCtx != nullptr)
@@ -65,27 +78,40 @@ void ReadHandler::Shutdown(ShutdownOptions aOptions)
         }
     }
 
-    if (IsReporting())
+    if (IsAwaitingReportResponse())
     {
         InteractionModelEngine::GetInstance()->GetReportingEngine().OnReportConfirm();
     }
     InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpAttributeClusterInfoList);
     InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpEventClusterInfoList);
-    mpExchangeCtx = nullptr;
+    mSubscriptionId     = 0;
+    mMinIntervalSeconds = 0;
+    mMaxIntervalSeconds = 0;
+    mInteractionType    = InteractionType::Read;
+    mpExchangeCtx       = nullptr;
     MoveToState(HandlerState::Uninitialized);
     mpAttributeClusterInfoList = nullptr;
     mpEventClusterInfoList     = nullptr;
     mCurrentPriority           = PriorityLevel::Invalid;
     mInitialReport             = false;
     mpDelegate                 = nullptr;
+    mHoldReport                = false;
+    mDirty                     = false;
 }
 
 CHIP_ERROR ReadHandler::OnReadInitialRequest(System::PacketBufferHandle && aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle response;
+    if (IsSubscriptionType())
+    {
+        err = ProcessSubscribeRequest(std::move(aPayload));
+    }
+    else
+    {
+        err = ProcessReadRequest(std::move(aPayload));
+    }
 
-    err = ProcessReadRequest(std::move(aPayload));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogFunctError(err);
@@ -108,10 +134,26 @@ CHIP_ERROR ReadHandler::OnStatusReport(Messaging::ExchangeContext * apExchangeCo
                  err = CHIP_ERROR_INVALID_ARGUMENT);
     switch (mState)
     {
-    case HandlerState::Reporting:
-        Shutdown();
+    case HandlerState::AwaitingReportResponse:
+        if (IsSubscriptionType())
+        {
+            InteractionModelEngine::GetInstance()->GetReportingEngine().OnReportConfirm();
+            if (IsInitialReport())
+            {
+                err = SendSubscribeResponse();
+                SuccessOrExit(err);
+            }
+            else
+            {
+                MoveToState(HandlerState::GeneratingReports);
+            }
+        }
+        else
+        {
+            Shutdown();
+        }
         break;
-    case HandlerState::Reportable:
+    case HandlerState::GeneratingReports:
     case HandlerState::Initialized:
     case HandlerState::Uninitialized:
     default:
@@ -129,14 +171,31 @@ exit:
 CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload)
 {
     VerifyOrReturnLogError(IsReportable(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
     if (IsInitialReport())
     {
         VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        mSessionHandle.SetValue(mpExchangeCtx->GetSecureSession());
+    }
+    else
+    {
+        mpExchangeCtx = mpExchangeMgr->NewContext(mSessionHandle.Value(), this);
+        mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
     }
     VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    MoveToState(HandlerState::Reporting);
-    return mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
-                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    MoveToState(HandlerState::AwaitingReportResponse);
+    CHIP_ERROR err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
+                                                Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    if (err == CHIP_NO_ERROR)
+    {
+        if (IsSubscriptionType() && !IsInitialReport())
+        {
+            err = RefreshSubscribeSyncTimer();
+        }
+    }
+    ClearDirty();
+    ChipLogFunctError(err);
+    return err;
 }
 
 CHIP_ERROR ReadHandler::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
@@ -220,7 +279,7 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
         err = CHIP_NO_ERROR;
     }
 
-    MoveToState(HandlerState::Reportable);
+    MoveToState(HandlerState::GeneratingReports);
 
     err = InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
     SuccessOrExit(err);
@@ -283,15 +342,10 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathList::Parser & aAt
         }
         SuccessOrExit(err);
 
-        if (MergeOverlappedAttributePath(clusterInfo))
-        {
-            continue;
-        }
-        else
+        if (!InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(mpAttributeClusterInfoList, clusterInfo))
         {
             err = InteractionModelEngine::GetInstance()->PushFront(mpAttributeClusterInfoList, clusterInfo);
             SuccessOrExit(err);
-            mpAttributeClusterInfoList->SetDirty();
             mInitialReport = true;
         }
     }
@@ -304,31 +358,6 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathList::Parser & aAt
 exit:
     ChipLogFunctError(err);
     return err;
-}
-
-bool ReadHandler::MergeOverlappedAttributePath(ClusterInfo & aAttributePath)
-{
-    ClusterInfo * runner = mpAttributeClusterInfoList;
-    while (runner != nullptr)
-    {
-        // If overlapped, we would skip this target path,
-        // --If targetPath is part of previous path, return true
-        // --If previous path is part of target path, update filedid and listindex and mflags with target path, return true
-        if (runner->IsAttributePathSupersetOf(aAttributePath))
-        {
-            return true;
-        }
-        if (aAttributePath.IsAttributePathSupersetOf(*runner))
-        {
-            runner->mListIndex = aAttributePath.mListIndex;
-            runner->mFieldId   = aAttributePath.mFieldId;
-            runner->mFlags     = aAttributePath.mFlags;
-            runner->SetDirty();
-            return true;
-        }
-        runner = runner->mpNext;
-    }
-    return false;
 }
 
 CHIP_ERROR ReadHandler::ProcessEventPathList(EventPathList::Parser & aEventPathListParser)
@@ -387,11 +416,11 @@ const char * ReadHandler::GetStateStr() const
     case HandlerState::Initialized:
         return "Initialized";
 
-    case HandlerState::Reportable:
-        return "Reportable";
+    case HandlerState::GeneratingReports:
+        return "GeneratingReports";
 
-    case HandlerState::Reporting:
-        return "Reporting";
+    case HandlerState::AwaitingReportResponse:
+        return "AwaitingReportResponse";
     }
 #endif // CHIP_DETAIL_LOGGING
     return "N/A";
@@ -444,6 +473,106 @@ void ReadHandler::MoveToNextScheduledDirtyPriority()
     }
 
     mCurrentPriority = PriorityLevel::Invalid;
+}
+
+CHIP_ERROR ReadHandler::SendSubscribeResponse()
+{
+    System::PacketBufferHandle packet = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
+    VerifyOrReturnLogError(!packet.IsNull(), CHIP_ERROR_NO_MEMORY);
+
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(packet));
+
+    SubscribeResponse::Builder response;
+    ReturnLogErrorOnFailure(response.Init(&writer));
+    response.SubscriptionId(mSubscriptionId).FinalSyncIntervalSeconds(mMaxIntervalSeconds).EndOfSubscribeResponse();
+    ReturnLogErrorOnFailure(response.GetError());
+
+    ReturnLogErrorOnFailure(writer.Finalize(&packet));
+    VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    ReturnLogErrorOnFailure(RefreshSubscribeSyncTimer());
+    mInitialReport = false;
+    MoveToState(HandlerState::GeneratingReports);
+    if (mpDelegate != nullptr)
+    {
+        mpDelegate->SubscriptionEstablished(this);
+    }
+    return mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::SubscribeResponse, std::move(packet));
+}
+
+CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aPayload)
+{
+    System::PacketBufferTLVReader reader;
+    reader.Init(std::move(aPayload));
+
+    ReturnLogErrorOnFailure(reader.Next());
+    SubscribeRequest::Parser subscribeRequestParser;
+    ReturnLogErrorOnFailure(subscribeRequestParser.Init(reader));
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    ReturnLogErrorOnFailure(subscribeRequestParser.CheckSchemaValidity());
+#endif
+
+    AttributePathList::Parser attributePathListParser;
+    CHIP_ERROR err = subscribeRequestParser.GetAttributePathList(&attributePathListParser);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    else if (err == CHIP_NO_ERROR)
+    {
+        ReturnLogErrorOnFailure(ProcessAttributePathList(attributePathListParser));
+    }
+    ReturnLogErrorOnFailure(err);
+
+    EventPathList::Parser eventPathListParser;
+    err = subscribeRequestParser.GetEventPathList(&eventPathListParser);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    else if (err == CHIP_NO_ERROR)
+    {
+        ReturnLogErrorOnFailure(ProcessEventPathList(eventPathListParser));
+    }
+    ReturnLogErrorOnFailure(err);
+
+    ReturnLogErrorOnFailure(subscribeRequestParser.GetMinIntervalSeconds(&mMinIntervalSeconds));
+    ReturnLogErrorOnFailure(subscribeRequestParser.GetMaxIntervalSeconds(&mMaxIntervalSeconds));
+
+    // TODO: Use GetSecureRandomData to generate subscription id
+    // it needs #include <support/crypto/CHIPRNG.h>, but somehow CHIPRNG.h is missing
+    // err = Platform::Security::GetSecureRandomData((uint8_t *) &mSubscriptionId, sizeof(mSubscriptionId));
+    // SuccessOrExit(err);
+    mSubscriptionId = GetRandU64();
+
+    MoveToState(HandlerState::GeneratingReports);
+
+    InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+    // mpExchangeCtx can be null here due to
+    // https://github.com/project-chip/connectedhomeip/issues/8031
+    if (mpExchangeCtx)
+    {
+        mpExchangeCtx->WillSendMessage();
+    }
+    return CHIP_NO_ERROR;
+}
+
+void ReadHandler::OnRefreshSubscribeTimerSyncCallback(System::Layer * apSystemLayer, void * apAppState)
+{
+    ReadHandler * aReadHandler = static_cast<ReadHandler *>(apAppState);
+    aReadHandler->mHoldReport  = false;
+    InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+}
+
+CHIP_ERROR ReadHandler::RefreshSubscribeSyncTimer()
+{
+    ChipLogProgress(DataManagement, "ReadHandler::Refresh Subscribe Sync Timer with %d seconds", mMinIntervalSeconds);
+    InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->CancelTimer(
+        OnRefreshSubscribeTimerSyncCallback, this);
+    mHoldReport = true;
+    return InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->StartTimer(
+        mMinIntervalSeconds * kMillisecondsPerSecond, OnRefreshSubscribeTimerSyncCallback, this);
 }
 } // namespace app
 } // namespace chip

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -56,6 +56,12 @@ public:
         AbortCurrentExchange,
     };
 
+    enum class InteractionType : uint8_t
+    {
+        Read,
+        Subscribe,
+    };
+
     /**
      *  Initialize the ReadHandler. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -68,7 +74,7 @@ public:
      *
      */
     CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
-                    Messaging::ExchangeContext * apExchangeContext);
+                    Messaging::ExchangeContext * apExchangeContext, InteractionType aInteractionType);
 
     /**
      *  Shut down the ReadHandler. This terminates this instance
@@ -77,7 +83,7 @@ public:
      */
     void Shutdown(ShutdownOptions aOptions = ShutdownOptions::KeepCurrentExchange);
     /**
-     *  Process a read request.  Parts of the processing may end up being asynchronous, but the ReadHandler
+     *  Process a read/subscribe request.  Parts of the processing may end up being asynchronous, but the ReadHandler
      *  guarantees that it will call Shutdown on itself when processing is done (including if OnReadInitialRequest
      *  returns an error).
      *
@@ -99,8 +105,9 @@ public:
     CHIP_ERROR SendReportData(System::PacketBufferHandle && aPayload);
 
     bool IsFree() const { return mState == HandlerState::Uninitialized; }
-    bool IsReportable() const { return mState == HandlerState::Reportable; }
-    bool IsReporting() const { return mState == HandlerState::Reporting; }
+    bool IsReportable() const { return mState == HandlerState::GeneratingReports && !mHoldReport; }
+    bool IsGeneratingReports() const { return mState == HandlerState::GeneratingReports; }
+    bool IsAwaitingReportResponse() const { return mState == HandlerState::AwaitingReportResponse; }
     virtual ~ReadHandler() = default;
 
     ClusterInfo * GetAttributeClusterInfolist() { return mpAttributeClusterInfoList; }
@@ -117,17 +124,30 @@ public:
     // is larger than current self vended event number
     void MoveToNextScheduledDirtyPriority();
 
+    bool IsReadType() { return mInteractionType == InteractionType::Read; }
+    bool IsSubscriptionType() { return mInteractionType == InteractionType::Subscribe; }
     bool IsInitialReport() { return mInitialReport; }
+    CHIP_ERROR OnSubscribeRequest(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
+    void GetSubscriptionId(uint64_t & aSubscriptionId) { aSubscriptionId = mSubscriptionId; }
+    void SetDirty() { mDirty = true; }
+    void ClearDirty() { mDirty = false; }
+    bool IsDirty() { return mDirty; }
 
 private:
+    friend class TestReadInteraction;
     enum class HandlerState
     {
-        Uninitialized = 0, ///< The handler has not been initialized
-        Initialized,       ///< The handler has been initialized and is ready
-        Reportable,        ///< The handler has received read request and is waiting for the data to send to be available
-        Reporting,         ///< The handler is reporting
+        Uninitialized = 0,      ///< The handler has not been initialized
+        Initialized,            ///< The handler has been initialized and is ready
+        GeneratingReports,      ///< The handler has received either a Read or Subscribe request and is the process of generating a
+                                ///< report.
+        AwaitingReportResponse, ///< The handler has sent the report to the client and is awaiting a status response.
     };
 
+    static void OnRefreshSubscribeTimerSyncCallback(System::Layer * apSystemLayer, void * apAppState);
+    CHIP_ERROR RefreshSubscribeSyncTimer();
+    CHIP_ERROR SendSubscribeResponse();
+    CHIP_ERROR ProcessSubscribeRequest(System::PacketBufferHandle && aPayload);
     CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle && aPayload);
     CHIP_ERROR ProcessAttributePathList(AttributePathList::Parser & aAttributePathListParser);
     CHIP_ERROR ProcessEventPathList(EventPathList::Parser & aEventPathListParser);
@@ -140,9 +160,6 @@ private:
     void MoveToState(const HandlerState aTargetState);
 
     const char * GetStateStr() const;
-
-    // Merges aAttributePath inside the existing internal mpAttributeClusterInfoList
-    bool MergeOverlappedAttributePath(ClusterInfo & aAttributePath);
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
 
@@ -164,6 +181,13 @@ private:
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
     bool mInitialReport                        = false;
+    InteractionType mInteractionType           = InteractionType::Read;
+    uint64_t mSubscriptionId                   = 0;
+    uint16_t mMinIntervalSeconds               = 0;
+    uint16_t mMaxIntervalSeconds               = 0;
+    Optional<SessionHandle> mSessionHandle;
+    bool mHoldReport = false;
+    bool mDirty      = false;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -38,6 +38,15 @@ CHIP_ERROR Engine::Init()
     return CHIP_NO_ERROR;
 }
 
+void Engine::Shutdown()
+{
+    mMoreChunkedMessages = false;
+    mNumReportsInFlight  = 0;
+    mCurReadHandlerIdx   = 0;
+    InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpChangePathList);
+    mpChangePathList = nullptr;
+}
+
 EventNumber Engine::CountEvents(ReadHandler * apReadHandler, EventNumber * apInitialEvents)
 {
     EventNumber event_count             = 0;
@@ -76,8 +85,6 @@ Engine::RetrieveClusterData(AttributeDataList::Builder & aAttributeDataList, Clu
     err = attributeDataElementBuilder.GetError();
 
 exit:
-    aClusterInfo.ClearDirty();
-
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DataManagement, "Error retrieving data from clusterId: " ChipLogFormatMEI ", err = %" CHIP_ERROR_FORMAT,
@@ -89,29 +96,46 @@ exit:
 
 CHIP_ERROR Engine::BuildSingleReportDataAttributeDataList(ReportData::Builder & aReportDataBuilder, ReadHandler * apReadHandler)
 {
-    CHIP_ERROR err            = CHIP_NO_ERROR;
-    ClusterInfo * clusterInfo = apReadHandler->GetAttributeClusterInfolist();
-    bool attributeClean       = true;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    bool attributeClean = true;
     TLV::TLVWriter backup;
     aReportDataBuilder.Checkpoint(backup);
     AttributeDataList::Builder attributeDataList = aReportDataBuilder.CreateAttributeDataListBuilder();
     SuccessOrExit(err = aReportDataBuilder.GetError());
     // TODO: Need to handle multiple chunk of message
-    while (clusterInfo != nullptr)
+    for (auto clusterInfo = apReadHandler->GetAttributeClusterInfolist(); clusterInfo != nullptr; clusterInfo = clusterInfo->mpNext)
     {
-        if (clusterInfo->IsDirty())
+        if (apReadHandler->IsInitialReport())
         {
-            if (apReadHandler->IsInitialReport())
+            // Retrieve data for this cluster instance and clear its dirty flag.
+            err = RetrieveClusterData(attributeDataList, *clusterInfo);
+            VerifyOrExit(err == CHIP_NO_ERROR,
+                         ChipLogError(DataManagement, "<RE:Run> Error retrieving data from cluster, aborting"));
+            attributeClean = false;
+        }
+        else
+        {
+            for (auto path = mpChangePathList; path != nullptr; path = path->mpNext)
             {
-                // Retrieve data for this cluster instance and clear its dirty flag.
-                err = RetrieveClusterData(attributeDataList, *clusterInfo);
+                if (clusterInfo->IsAttributePathSupersetOf(*path))
+                {
+                    err = RetrieveClusterData(attributeDataList, *path);
+                }
+                else if (path->IsAttributePathSupersetOf(*clusterInfo))
+                {
+                    err = RetrieveClusterData(attributeDataList, *clusterInfo);
+                }
+                else
+                {
+                    // partial overlap is not possible, hence the 'continue' here: clusterInfo and path have nothing in
+                    // common.
+                    continue;
+                }
                 VerifyOrExit(err == CHIP_NO_ERROR,
                              ChipLogError(DataManagement, "<RE:Run> Error retrieving data from cluster, aborting"));
                 attributeClean = false;
             }
-            clusterInfo->ClearDirty();
         }
-        clusterInfo = clusterInfo->mpNext;
     }
     attributeDataList.EndOfAttributeDataList();
     err = attributeDataList.GetError();
@@ -244,6 +268,13 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
     err = reportDataBuilder.Init(&reportDataWriter);
     SuccessOrExit(err);
 
+    if (apReadHandler->IsSubscriptionType())
+    {
+        uint64_t subscriptionId = 0;
+        apReadHandler->GetSubscriptionId(subscriptionId);
+        reportDataBuilder.SubscriptionId(subscriptionId);
+    }
+
     err = BuildSingleReportDataAttributeDataList(reportDataBuilder, apReadHandler);
     SuccessOrExit(err);
 
@@ -336,6 +367,67 @@ void Engine::Run()
         mCurReadHandlerIdx = (mCurReadHandlerIdx + 1) % CHIP_IM_MAX_NUM_READ_HANDLER;
         readHandler        = imEngine->mReadHandlers + mCurReadHandlerIdx;
     }
+
+    bool allReadClean = true;
+    for (auto & handler : InteractionModelEngine::GetInstance()->mReadHandlers)
+    {
+        UpdateReadHandlerDirty(handler);
+        if (handler.IsDirty())
+        {
+            allReadClean = false;
+            break;
+        }
+    }
+
+    if (allReadClean)
+    {
+        InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpChangePathList);
+    }
+}
+
+CHIP_ERROR Engine::SetDirty(ClusterInfo & aClusterInfo)
+{
+    for (auto & handler : InteractionModelEngine::GetInstance()->mReadHandlers)
+    {
+        if (handler.IsSubscriptionType() && (handler.IsGeneratingReports() || handler.IsAwaitingReportResponse()))
+        {
+            handler.SetDirty();
+        }
+    }
+    if (!InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(mpChangePathList, aClusterInfo) &&
+        InteractionModelEngine::GetInstance()->IsOverlappedAttributePath(aClusterInfo))
+    {
+        ReturnLogErrorOnFailure(InteractionModelEngine::GetInstance()->PushFront(mpChangePathList, aClusterInfo));
+    }
+    return CHIP_NO_ERROR;
+}
+
+void Engine::UpdateReadHandlerDirty(ReadHandler & aReadHandler)
+{
+    if (!aReadHandler.IsDirty())
+    {
+        return;
+    }
+    if (!aReadHandler.IsSubscriptionType())
+    {
+        return;
+    }
+    for (auto clusterInfo = aReadHandler.GetAttributeClusterInfolist(); clusterInfo != nullptr; clusterInfo = clusterInfo->mpNext)
+    {
+        bool intersected = false;
+        for (auto path = mpChangePathList; path != nullptr; path = path->mpNext)
+        {
+            if (path->IsAttributePathSupersetOf(*clusterInfo) || clusterInfo->IsAttributePathSupersetOf(*path))
+            {
+                ChipLogDetail(DataManagement, "<RE> CleanReadHandlerSubscribeDirty is called");
+                intersected = true;
+            }
+        }
+        if (!intersected)
+        {
+            aReadHandler.ClearDirty();
+        }
+    }
 }
 
 CHIP_ERROR Engine::SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload)
@@ -344,7 +436,6 @@ CHIP_ERROR Engine::SendReport(ReadHandler * apReadHandler, System::PacketBufferH
 
     // We can only have 1 report in flight for any given read - increment and break out.
     mNumReportsInFlight++;
-
     err = apReadHandler->SendReportData(std::move(aPayload));
     return err;
 }

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -60,6 +60,8 @@ public:
      */
     CHIP_ERROR Init();
 
+    void Shutdown();
+
     /**
      * Main work-horse function that executes the run-loop.
      */
@@ -77,6 +79,11 @@ public:
      */
     CHIP_ERROR ScheduleRun();
 
+    /**
+     * Application marks mutated change path and would be sent out in later report.
+     */
+    CHIP_ERROR SetDirty(ClusterInfo & aClusterInfo);
+
 private:
     friend class TestReportingEngine;
     /**
@@ -90,6 +97,7 @@ private:
     CHIP_ERROR RetrieveClusterData(AttributeDataList::Builder & aAttributeDataList, ClusterInfo & aClusterInfo);
     EventNumber CountEvents(ReadHandler * apReadHandler, EventNumber * apInitialEvents);
 
+    void UpdateReadHandlerDirty(ReadHandler & aReadHandler);
     /**
      * Send Report via ReadHandler
      *
@@ -119,6 +127,8 @@ private:
      *
      */
     uint32_t mCurReadHandlerIdx = 0;
+
+    ClusterInfo * mpChangePathList = nullptr;
 };
 
 }; // namespace reporting

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -29,15 +29,6 @@
 namespace chip {
 namespace app {
 namespace TestClusterInfo {
-void TestDirty(nlTestSuite * apSuite, void * apContext)
-{
-    ClusterInfo clusterInfo1;
-    clusterInfo1.SetDirty();
-    NL_TEST_ASSERT(apSuite, clusterInfo1.IsDirty());
-    clusterInfo1.ClearDirty();
-    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsDirty());
-}
-
 void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContext)
 {
     ClusterInfo clusterInfo1;
@@ -104,7 +95,6 @@ void TestAttributePathIncludedDifferentClusterId(nlTestSuite * apSuite, void * a
 
 namespace {
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestDirty", chip::app::TestClusterInfo::TestDirty),
     NL_TEST_DEF("TestAttributePathIncludedSameFieldId", chip::app::TestClusterInfo::TestAttributePathIncludedSameFieldId),
     NL_TEST_DEF("TestAttributePathIncludedDifferentFieldId", chip::app::TestClusterInfo::TestAttributePathIncludedDifferentFieldId),
     NL_TEST_DEF("TestAttributePathIncludedDifferentEndpointId",

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -49,12 +49,12 @@ static SecureSessionMgr gSessionManager;
 static Messaging::ExchangeManager gExchangeManager;
 static TransportMgr<Transport::UDP> gTransportManager;
 static secure_channel::MessageCounterManager gMessageCounterManager;
-constexpr ClusterId kTestClusterId    = 6;
-constexpr EndpointId kTestEndpointId  = 1;
-constexpr chip::FieldId kTestFieldId1 = 1;
-constexpr chip::FieldId kTestFieldId2 = 2;
-constexpr uint8_t kTestFieldValue1    = 1;
-constexpr uint8_t kTestFieldValue2    = 2;
+constexpr ClusterId kTestClusterId        = 6;
+constexpr EndpointId kTestEndpointId      = 1;
+constexpr chip::AttributeId kTestFieldId1 = 1;
+constexpr chip::AttributeId kTestFieldId2 = 2;
+constexpr uint8_t kTestFieldValue1        = 1;
+constexpr uint8_t kTestFieldValue2        = 2;
 
 namespace app {
 CHIP_ERROR ReadSingleClusterData(AttributePathParams & aAttributePathParams, TLV::TLVWriter * apWriter, bool * apDataExists)
@@ -102,7 +102,6 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::ReadHandler readHandler;
-    Engine reportingEngine;
     System::PacketBufferTLVWriter writer;
     System::PacketBufferHandle readRequestbuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
     ReadRequest::Builder readRequestBuilder;
@@ -122,22 +121,34 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
     attributePathBuilder = attributePathListBuilder.CreateAttributePathBuilder();
     NL_TEST_ASSERT(apSuite, attributePathListBuilder.GetError() == CHIP_NO_ERROR);
-    attributePathBuilder =
-        attributePathBuilder.NodeId(1).EndpointId(kTestEndpointId).ClusterId(kTestClusterId).FieldId(0).EndOfAttributePath();
+    attributePathBuilder = attributePathBuilder.NodeId(1)
+                               .EndpointId(kTestEndpointId)
+                               .ClusterId(kTestClusterId)
+                               .FieldId(kTestFieldId1)
+                               .EndOfAttributePath();
+    NL_TEST_ASSERT(apSuite, attributePathBuilder.GetError() == CHIP_NO_ERROR);
+
+    attributePathBuilder = attributePathListBuilder.CreateAttributePathBuilder();
+    NL_TEST_ASSERT(apSuite, attributePathListBuilder.GetError() == CHIP_NO_ERROR);
+    attributePathBuilder = attributePathBuilder.NodeId(1)
+                               .EndpointId(kTestEndpointId)
+                               .ClusterId(kTestClusterId)
+                               .FieldId(kTestFieldId2)
+                               .EndOfAttributePath();
     NL_TEST_ASSERT(apSuite, attributePathBuilder.GetError() == CHIP_NO_ERROR);
     attributePathListBuilder.EndOfAttributePathList();
-    readRequestBuilder.EventNumber(1);
+
     NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
     readRequestBuilder.EndOfReadRequest();
     NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
+    readHandler.Init(&gExchangeManager, nullptr, exchangeCtx, chip::app::ReadHandler::InteractionType::Read);
     readHandler.OnReadInitialRequest(std::move(readRequestbuf));
-    reportingEngine.Init();
-    err = reportingEngine.BuildAndSendSingleReportData(&readHandler);
-    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    err = InteractionModelEngine::GetInstance()->GetReportingEngine().BuildAndSendSingleReportData(&readHandler);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);
 }
+
 } // namespace reporting
 } // namespace app
 } // namespace chip

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -51,6 +51,9 @@ constexpr size_t kMaxWriteMessageCount            = 3;
 constexpr uint32_t gMessageIntervalMsec           = 1200;
 constexpr uint32_t gMessageTimeoutMsec            = 1000;
 constexpr chip::FabricIndex gFabricIndex          = 0;
+constexpr size_t kMaxSubMessageCount              = 1;
+constexpr int32_t gMessageIntervalSeconds         = 1;
+constexpr uint64_t gSubMaxReport                  = 5;
 
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::Inet::IPAddress gDestAddr;
@@ -76,6 +79,15 @@ uint64_t gWriteCount = 0;
 // Count of the number of WriteResponses received.
 uint64_t gWriteRespCount = 0;
 
+// Count of the number of SubscribeRequests sent.
+uint64_t gSubCount = 0;
+
+// Count of the number of SubscribeResponses received.
+uint64_t gSubRespCount = 0;
+
+// Count of the number of reports for subscription.
+uint64_t gSubReportCount = 0;
+
 // Whether the last command successed.
 enum class TestCommandResult : uint8_t
 {
@@ -90,6 +102,7 @@ void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appSta
 void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
 void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
 void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
+void SubscribeRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
 CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
 {
@@ -255,6 +268,54 @@ exit:
     return err;
 }
 
+CHIP_ERROR SendSubscribeRequest()
+{
+    CHIP_ERROR err   = CHIP_NO_ERROR;
+    gLastMessageTime = chip::System::Clock::GetMonotonicMilliseconds();
+
+    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex));
+    chip::app::EventPathParams eventPathParams[2];
+    chip::app::AttributePathParams attributePathParams[1];
+    readPrepareParams.mpEventPathParamsList                = eventPathParams;
+    readPrepareParams.mpEventPathParamsList[0].mNodeId     = kTestNodeId;
+    readPrepareParams.mpEventPathParamsList[0].mEndpointId = kTestEndpointId;
+    readPrepareParams.mpEventPathParamsList[0].mClusterId  = kTestClusterId;
+    readPrepareParams.mpEventPathParamsList[0].mEventId    = kTestChangeEvent1;
+
+    readPrepareParams.mpEventPathParamsList[1].mNodeId     = kTestNodeId;
+    readPrepareParams.mpEventPathParamsList[1].mEndpointId = kTestEndpointId;
+    readPrepareParams.mpEventPathParamsList[1].mClusterId  = kTestClusterId;
+    readPrepareParams.mpEventPathParamsList[1].mEventId    = kTestChangeEvent2;
+
+    readPrepareParams.mEventPathParamsListSize = 2;
+
+    readPrepareParams.mpAttributePathParamsList                = attributePathParams;
+    readPrepareParams.mpAttributePathParamsList[0].mNodeId     = chip::kTestDeviceNodeId;
+    readPrepareParams.mpAttributePathParamsList[0].mEndpointId = kTestEndpointId;
+    readPrepareParams.mpAttributePathParamsList[0].mClusterId  = kTestClusterId;
+    readPrepareParams.mpAttributePathParamsList[0].mFieldId    = 1;
+    readPrepareParams.mpAttributePathParamsList[0].mListIndex  = 0;
+    readPrepareParams.mpAttributePathParamsList[0].mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    readPrepareParams.mAttributePathParamsListSize = 1;
+
+    readPrepareParams.mMinIntervalSeconds = 2;
+    readPrepareParams.mMaxIntervalSeconds = 5;
+    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->SendSubscribeRequest(readPrepareParams);
+    SuccessOrExit(err);
+
+    gSubCount++;
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        printf("Send subscribe request failed, err: %s\n", chip::ErrorStr(err));
+    }
+    return err;
+}
+
 CHIP_ERROR EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -302,6 +363,15 @@ void HandleWriteComplete()
 
     printf("Write Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gWriteRespCount, gWriteCount,
            static_cast<double>(gWriteRespCount) * 100 / gWriteCount, static_cast<double>(transitTime) / 1000);
+}
+
+void HandleSubscribeReportComplete()
+{
+    uint32_t respTime    = chip::System::Clock::GetMonotonicMilliseconds();
+    uint32_t transitTime = respTime - gLastMessageTime;
+    gSubRespCount++;
+    printf("Subscribe Complete: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gSubRespCount, gSubCount,
+           static_cast<double>(gSubRespCount) * 100 / gSubCount, static_cast<double>(transitTime) / 1000);
 }
 
 void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
@@ -420,6 +490,39 @@ void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState
     }
     else
     {
+        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalSeconds * 1000, SubscribeRequestTimerHandler, NULL);
+        VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+    }
+}
+
+void SubscribeRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (gSubRespCount != gSubCount)
+    {
+        printf("No response received\n");
+
+        // Set gSubRespCount to gSubCount to start next iteration if there is any.
+        gSubRespCount = gSubCount;
+    }
+
+    if (gSubRespCount < kMaxSubMessageCount)
+    {
+        err = SendSubscribeRequest();
+        VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to send write request with error: %s\n", chip::ErrorStr(err)));
+
+        err = chip::DeviceLayer::SystemLayer.StartTimer(20 * 1000, SubscribeRequestTimerHandler, NULL);
+        VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
+    }
+    else
+    {
         // Complete all tests.
         chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
@@ -444,7 +547,20 @@ public:
     {
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override
+    {
+        if (apReadClient->IsSubscriptionType())
+        {
+            gSubReportCount++;
+            if (gSubReportCount == gSubMaxReport)
+            {
+                HandleSubscribeReportComplete();
+            }
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR ReadError(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
     {
         printf("ReadError with err %" CHIP_ERROR_FORMAT, aError.Format());
@@ -452,7 +568,10 @@ public:
     }
     CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient) override
     {
-        HandleReadComplete();
+        if (!apReadClient->IsSubscriptionType())
+        {
+            HandleReadComplete();
+        }
         return CHIP_NO_ERROR;
     }
     CHIP_ERROR CommandResponseStatus(const chip::app::CommandSender * apCommandSender,

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -141,6 +141,7 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
 } // namespace chip
 
 namespace {
+bool testSyncReport = false;
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
 LivenessEventGenerator gLivenessGenerator;
@@ -161,12 +162,47 @@ void InitializeEventLogging(chip::Messaging::ExchangeManager * apMgr)
     chip::app::EventManagement::CreateEventManagement(apMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]),
                                                       gCircularEventBuffer, logStorageResources);
 }
+
+void MutateClusterHandler(chip::System::Layer * systemLayer, void * appState)
+{
+    chip::app::ClusterInfo dirtyPath;
+    dirtyPath.mClusterId  = kTestClusterId;
+    dirtyPath.mEndpointId = kTestEndpointId;
+    dirtyPath.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
+    printf("MutateClusterHandler is triggered...");
+    // send dirty change
+    if (!testSyncReport)
+    {
+        dirtyPath.mFieldId = 1;
+        chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath);
+        chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+        chip::DeviceLayer::SystemLayer.StartTimer(1000, MutateClusterHandler, NULL);
+        testSyncReport = true;
+    }
+    else
+    {
+        dirtyPath.mFieldId = 10; // unknown field
+        chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(dirtyPath);
+        // send sync message(empty report)
+        chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+    }
+}
+
+class MockInteractionModelApp : public chip::app::InteractionModelDelegate
+{
+public:
+    virtual CHIP_ERROR SubscriptionEstablished(const chip::app::ReadHandler * apReadHandler)
+    {
+        chip::DeviceLayer::SystemLayer.StartTimer(1000, MutateClusterHandler, NULL);
+        return CHIP_NO_ERROR;
+    }
+};
 } // namespace
 
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::app::InteractionModelDelegate mockDelegate;
+    MockInteractionModelApp mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::FabricIndex gFabricIndex = 0;
     chip::Transport::FabricTable fabrics;

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -460,6 +460,22 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
                                                       : Protocols::SecureChannel::GeneralStatusCode::kFailure,
                                                   Protocols::SecureChannel::Id, imCode);
 }
-
 } // namespace app
 } // namespace chip
+
+void InteractionModelReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
+                                             uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
+{
+    IgnoreUnusedVariable(manufacturerCode);
+    IgnoreUnusedVariable(type);
+    IgnoreUnusedVariable(data);
+    IgnoreUnusedVariable(mask);
+
+    ClusterInfo info;
+    info.mClusterId  = clusterId;
+    info.mFieldId    = attributeId;
+    info.mEndpointId = endpoint;
+    info.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+
+    InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(info);
+}

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -463,8 +463,9 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
 } // namespace app
 } // namespace chip
 
-void InteractionModelReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                             uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
+void InteractionModelReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+                                                      uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type,
+                                                      uint8_t * data)
 {
     IgnoreUnusedVariable(manufacturerCode);
     IgnoreUnusedVariable(type);

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2439,7 +2439,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
  */
 #ifndef CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
-#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 4
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 7
 #endif
 
 /**


### PR DESCRIPTION
#### Problems:
Follow IM spec chapter 5 and IM encoding spec 7.3 and 7.4 to achieve
subscription functionality.
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Interaction-Model.adoc#5-subscribe-interaction
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Encoding-Specification.adoc#subscriberequestmessage

#### Change overview
- Establishing distinct subscriptions and tracking their respective configurations from multiple clients simultaneously.
- Sharing of reporting logic between reads and subscriptions to maximize re-use.
- Multiple paths per subscription
- Basic chunking of data across multiple reports.
- Automatic liveness assessment on client and server and termination of subscription accordingly.
- Eventing support in addition to attribute reporting.
- Spec compliance to the encoding specification with TLV-based payloads.
- Preservation of the application level APIs for client-side reporting, but with a swap of the internals to use the new machinery

#### Testing
-- Add unit test for positive and negative subscribe test
-- Add integrated cirque test for subscribe.

